### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -42,7 +42,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@2.11
+        uses: elgohr/Publish-Docker-Github-Action@v5
         env:
           GIT_VERSION: ${{ env.APP_VERSION }}
           GIT_BUILD: ${{ env.APP_BUILD }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore